### PR TITLE
345 feature instant resolution for already fetched images in prefetch

### DIFF
--- a/ios/TurboImageViewManager.swift
+++ b/ios/TurboImageViewManager.swift
@@ -40,7 +40,9 @@ extension TurboImageViewManager {
       prefetcher = ImagePrefetcher()
     }
     prefetcher?.startPrefetching(with: imageRequests)
-    resolve("Success")
+    prefetcher?.didComplete = {
+      resolve(true)
+    }
   }
 
   @objc
@@ -69,7 +71,7 @@ extension TurboImageViewManager {
     ImageCache.shared.removeAll()
     resolve("Success")
   }
-
+  
   @objc
   func clearDiskCache(_ resolve: @escaping RCTPromiseResolveBlock,
                       reject: @escaping RCTPromiseRejectBlock) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface TurboImageProps extends AccessibilityProps, ViewProps {
 }
 
 export type TurboImageApi = {
-  prefetch: (sources: Source[], cachePolicy?: CachePolicy) => Promise<void>;
+  prefetch: (sources: Source[], cachePolicy?: CachePolicy) => Promise<boolean>;
   dispose: (sources: Source[]) => Promise<void>;
   clearMemoryCache: () => Promise<void>;
   clearDiskCache: () => Promise<void>;


### PR DESCRIPTION
resolve to `true` when the prefetching completes for all the scheduled requests, regardless of whether the requests succeed or some fail.

- iOS https://github.com/duguyihou/react-native-turbo-image/issues/345#issuecomment-2343167034
- android https://github.com/duguyihou/react-native-turbo-image/issues/345#issuecomment-2350893936