### PR TITLE
fix: set minimum iOS version requirement to 13.0

### DIFF
--- a/react-native-turbo-image.podspec
+++ b/react-native-turbo-image.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported, :tvos => "13.0" }
+  s.platforms    = { :ios => "13.0", :tvos => "13.0" }
   s.source       = { :git => "https://github.com/duguyihou/react-native-turbo-image.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/49687469-66ff-4843-bb47-138ce1c8077f)

![image](https://github.com/user-attachments/assets/e61ebd90-8e3e-40db-9e20-be732335e2f4)

My project is using iOS 12.4, and I’m encountering a compilation error. The library in question requires iOS 13.0 or higher. The previously set min_ios_version_supported is subject to change dynamically. Therefore, to ensure compatibility across all projects, I will fix it to 13.0