### PR TITLE
Guard against zero-sized thumbhash bitmaps

### DIFF
--- a/android/src/main/java/com/turboimage/TurboImageView.kt
+++ b/android/src/main/java/com/turboimage/TurboImageView.kt
@@ -98,16 +98,35 @@ class TurboImageView(private val reactContext: ThemedReactContext) :
 
   private fun drawThumbhash(view: TurboImageView, hash: String): Drawable {
     val image = ThumbHash.thumbHashToRGBA(Base64.decode(hash, Base64.DEFAULT))
-    val intArray = IntArray(image.width * image.height)
-    for (i in intArray.indices) {
-      val r = image.rgba[i * 4].toInt() and 0xFF
-      val g = image.rgba[i * 4 + 1].toInt() and 0xFF
-      val b = image.rgba[i * 4 + 2].toInt() and 0xFF
-      val a = image.rgba[i * 4 + 3].toInt() and 0xFF
-      intArray[i] =
-        ((a and 0xff) shl 24) or ((r and 0xff) shl 16) or ((g and 0xff) shl 8) or (b and 0xff)
+
+    // Guard against invalid dimensions
+    val width = maxOf(image.width, 1)
+    val height = maxOf(image.height, 1)
+
+    val pixelCount = width * height
+    val intArray = IntArray(pixelCount)
+
+    // Only read as many pixels as actually exist
+    val maxPixels = minOf(image.width * image.height, pixelCount)
+
+    for (i in 0 until maxPixels) {
+        val base = i * 4
+        val r = image.rgba[base].toInt() and 0xFF
+        val g = image.rgba[base + 1].toInt() and 0xFF
+        val b = image.rgba[base + 2].toInt() and 0xFF
+        val a = image.rgba[base + 3].toInt() and 0xFF
+
+        intArray[i] =
+            (a shl 24) or (r shl 16) or (g shl 8) or b
     }
-    val bitmap = Bitmap.createBitmap(intArray, image.width, image.height, Bitmap.Config.ARGB_8888)
+
+    val bitmap = Bitmap.createBitmap(
+        intArray,
+        width,
+        height,
+        Bitmap.Config.ARGB_8888
+    )
+
     return BitmapDrawable(view.context.resources, bitmap)
   }
 


### PR DESCRIPTION
# Summary

This PR fixes a crash caused by zero-sized bitmaps when rendering thumbhash placeholders.

In rare cases, ThumbHash.thumbHashToRGBA(...) returns an image with a width or height of 0. Passing these dimensions into Bitmap.createBitmap causes a runtime crash during draw, typically triggered by Coil’s crossfade or BitmapDrawable.draw.

# Crash
Android 13 (SDK 33)
Android 15 (SDK 35)
nubia P780F01
ZTE P606F08
ZTE P963F64
App: [Abandoned World - Urbex](https://play.google.com/store/apps/details?id=com.abandonedWorld)

```
Exception java.lang.IllegalArgumentException: width and height must be > 0
  at android.graphics.Bitmap.createBitmap (Bitmap.java:1111)
  at android.graphics.Bitmap.createBitmap (Bitmap.java:950)
  at android.graphics.Bitmap.createScaledBitmap (Bitmap.java:805)
  at android.graphics.drawable.BitmapDrawable.draw (BitmapDrawable.java:571)
  at coil.drawable.CrossfadeDrawable.draw (CrossfadeDrawable.kt:79)
  at android.widget.ImageView.onDraw (ImageView.java:1446)
  at android.view.View.draw (View.java:23369)
  at android.view.View.draw (View.java:23231)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23376)
  at com.facebook.react.views.view.ReactViewGroup.draw (ReactViewGroup.kt:906)
  at android.view.View.draw (View.java:23231)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23376)
  at com.facebook.react.views.view.ReactViewGroup.draw (ReactViewGroup.kt:906)
  at android.view.View.draw (View.java:23231)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23376)
  at android.view.View.draw (View.java:23231)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23376)
  at com.facebook.react.views.view.ReactViewGroup.draw (ReactViewGroup.kt:906)
  at android.view.View.draw (View.java:23231)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.views.view.ReactViewGroup.drawChild (ReactViewGroup.kt:945)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.views.view.ReactViewGroup.dispatchDraw (ReactViewGroup.kt:914)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at com.facebook.react.ReactRootView.drawChild (ReactRootView.java:321)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at com.facebook.react.ReactRootView.dispatchDraw (ReactRootView.java:298)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23229)
  at android.view.ViewGroup.drawChild (ViewGroup.java:4608)
  at android.view.ViewGroup.dispatchDraw (ViewGroup.java:4369)
  at android.view.View.draw (View.java:23376)
  at com.android.internal.policy.DecorView.draw (DecorView.java:879)
  at com.qmdeve.blurview.base.BaseBlurViewGroup.performBlurSync (BaseBlurViewGroup.java:359)
  at com.qmdeve.blurview.base.BaseBlurViewGroup$1.onPreDraw (BaseBlurViewGroup.java:413)
  at android.view.ViewTreeObserver.dispatchOnPreDraw (ViewTreeObserver.java:1093)
  at android.view.ViewRootImpl.performTraversals (ViewRootImpl.java:3744)
  at android.view.ViewRootImpl.doTraversal (ViewRootImpl.java:2477)
  at android.view.ViewRootImpl$TraversalRunnable.run (ViewRootImpl.java:9299)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1256)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1264)
  at android.view.Choreographer.doCallbacks (Choreographer.java:924)
  at android.view.Choreographer.doFrame (Choreographer.java:857)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1239)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:235)
  at android.os.Looper.loop (Looper.java:350)
  at android.app.ActivityThread.main (ActivityThread.java:8798)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:703)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:911)
  ```
  
# Root cause
	•	Thumbhash decoding can yield width == 0 or height == 0
	•	Android’s bitmap APIs require dimensions > 0
	•	The crash occurs during rendering, not during decode, which makes it harder to trace

# Fix
	•	Clamp decoded thumbhash dimensions to a minimum of 1x1
	•	Allocate the pixel buffer using the sanitized dimensions
	•	Safely copy only the available RGBA pixels

# This ensures:
	•	No invalid bitmap allocations
	•	No array bounds issues
	•	Stable rendering even for malformed or edge-case thumbhashes

# Scope
	•	Fix is intentionally limited to drawThumbhash
	•	No changes to thumbhash generation or composition logic
	•	No behavior change for valid hashes
